### PR TITLE
feat: add kube-metrics plugin

### DIFF
--- a/plugins/kube-metrics.yaml
+++ b/plugins/kube-metrics.yaml
@@ -1,0 +1,20 @@
+# requires 'kube-metrics' cli binary installed to be installed (https://github.com/bakito/kube-metrics)
+plugins:
+  # allows visualizing pod and node metrics 
+  kube-metrics-pod:
+    shortCut: m
+    confirm: false
+    description: "Metrics"
+    scopes:
+      - pods
+      - nodes
+    command: sh
+    background: false
+    args:
+      - -c
+      - |
+        if [ -n "$NAMESPACE" ]; then
+          kube-metrics pod --namespace=$NAMESPACE $NAME
+        else
+          kube-metrics node $NAME
+        fi


### PR DESCRIPTION
This PR add a sample plugin to integrate [kube-metics](https://github.com/bakito/kube-metrics) as a k9s plugin.

[kube-metics](https://github.com/bakito/kube-metrics)  allows visualizing live metrics of pods and nodes.

